### PR TITLE
TypeError occurs if non-Error object is thrown and stack is undefined

### DIFF
--- a/lib/trycatch.js
+++ b/lib/trycatch.js
@@ -93,6 +93,7 @@ function stackSearch(error, structuredStackTrace) {
 var filename1 = __filename;
 var filename2 = require.resolve('./hook');
 function filterInternalFrames(frames) {
+        if (!frames) return "";   //if non-Error was thrown, frames might be undefined
 	var ret = [];
 	return frames.split("\n").filter(function(frame) {
 		return frame.indexOf(filename1) < 0 && frame.indexOf(filename2) < 0;

--- a/test/throw-string.test.js
+++ b/test/throw-string.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+var assert = require('assert');
+var trycatch = require('../lib/trycatch');
+
+/*
+  This test is to test whether trycatch can handle non-Errors being thrown
+  like string, number, boolean.
+
+  Before the fix, there was an error in
+  trycatch.js filterInternalFrames() line 97
+
+  TypeError: Cannot call method 'split' of undefined
+
+
+  To run this test:  node ./throw-string.test.js
+ */ 
+
+//be compatible with running test from command line or from something like Expresso
+var EXIT = (require.main === module) ? 'exit' : 'beforeExit'; 
+
+exports['throwing non-Error object like string should be caught'] = function () {
+  var onErrorCalled = false;
+
+  trycatch(function () {
+    setTimeout(function () {
+      throw 'my-string being thrown';  //throwing a string non-Error object
+    }, 100);
+  }, function onError(err) {
+    onErrorCalled = true;
+    assert.equal(err, 'my-string being thrown');
+    assert.equal(err.stack, undefined);
+  });
+  
+  process.on(EXIT, function () {
+    //check callbacks were called here
+    assert.equal(onErrorCalled, true, 'throw string onError function should have been called');
+    console.error('success - caught thrown String');
+  });
+  
+};
+
+exports['throwing non-Error object like number should be caught'] = function () {
+  var onErrorCalled = false;
+
+  trycatch(function () {
+    setTimeout(function () {
+      throw 123;               //throwing a number non-Error object
+    }, 100);
+  }, function onError(err) {
+    onErrorCalled = true;
+    assert.equal(err, 123);
+    assert.equal(err.stack, undefined);
+  });
+  
+  process.on(EXIT, function () {
+    //check callbacks were called here
+    assert.equal(onErrorCalled, true, 'throw number onError function should have been called');
+    console.error('success - caught thrown number');
+  });
+  
+};
+
+exports['throwing non-Error object like boolean should be caught'] = function () {
+  var onErrorCalled = false;
+
+  trycatch(function () {
+    setTimeout(function () {
+      throw true;               //throwing a boolean non-Error object
+    }, 100);
+  }, function onError(err) {
+    onErrorCalled = true;
+    assert.equal(err, true);
+    assert.equal(err.stack, undefined);
+  });
+  
+  process.on(EXIT, function () {
+    //check callbacks were called here
+    assert.equal(onErrorCalled, true, 'throw boolean onError function should have been called');
+    console.error('success - caught thrown boolean');
+  });
+  
+};
+
+
+// if run directly from node execute all the exports
+if (require.main === module) Object.keys(exports).forEach(function (f) { exports[f](); });
+
+


### PR DESCRIPTION
If a non-Error object is thrown like string, number, boolean, etc.
a stack will not be available.

filterInternalFrames() was calling split on the frames array which
ends up being undefined and this causes an error.

```
 trycatch.js filterInternalFrames() line 97

 TypeError: Cannot call method 'split' of undefined
```

The fix is to simple check if frames is defined before continuing and
if not, then simply return empty string.

Run the included test by running:

``` bash
  node test/throw-string.test.js
```
