### PR TITLE
Default other lines to white

### DIFF
--- a/lib/formatStackTrace.js
+++ b/lib/formatStackTrace.js
@@ -62,7 +62,9 @@ function FormatStackTrace(error, frames, filter, colors) {
           line = colors.cyan(line);
         } else if (line.indexOf(d) >= 0) {
           line = colors.red(line);
-        }
+        } else {
+          line = colors.white(line);
+        } 
       }
 
       lines.push(line);


### PR DESCRIPTION
This helps with tools that apply default colors to the entire stack trace output.

Now all other lines are forced to be white.
